### PR TITLE
Add Free 75 promotional page

### DIFF
--- a/App.py
+++ b/App.py
@@ -21,6 +21,10 @@ def build_your_own():
 def personal_stats():
     return render_template('personal_stats.html')
 
+@app.route('/free-75')
+def free_75():
+    return render_template('free75.html')
+
 @app.route('/get_locks')
 def get_locks():
     sport = request.args.get('sport', 'nba').lower()

--- a/docs/build_your_own.html
+++ b/docs/build_your_own.html
@@ -14,6 +14,7 @@
       <a href="/premade">Premade Parlays</a>
       <a href="/build-your-own">Build Your Own</a>
       <a href="/personal-stats">Personal Stats</a>
+      <a href="/free-75">Free 75</a>
     </div>
   </div>
 

--- a/docs/free75.html
+++ b/docs/free75.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Free 75</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body class="free75-page">
+  <div class="dropdown">
+    <button class="dropbtn">☰ Menu</button>
+    <div class="dropdown-content">
+      <a href="/">Main</a>
+      <a href="/premade">Premade Parlays</a>
+      <a href="/build-your-own">Build Your Own</a>
+      <a href="/personal-stats">Personal Stats</a>
+      <a href="/free-75">Free 75</a>
+    </div>
+  </div>
+
+  <h1>Win a Free $75</h1>
+  <div class="free75-steps">
+    <div class="step">
+      <h2>Step 1</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    </div>
+    <div class="step">
+      <h2>Step 2</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    </div>
+    <div class="step">
+      <h2>Step 3</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    </div>
+    <div class="step">
+      <h2>Step 4</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    </div>
+  </div>
+
+  <script src="{{ url_for('static', filename='js/dropdown.js') }}"></script>
+</body>
+</html>
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,6 +20,7 @@
       <a href="/premade">Premade Parlays</a>
       <a href="/build-your-own">Build Your Own</a>
       <a href="/personal-stats">Personal Stats</a>
+      <a href="/free-75">Free 75</a>
     </div>
   </div>
 

--- a/docs/personal_stats.html
+++ b/docs/personal_stats.html
@@ -14,6 +14,7 @@
       <a href="/premade">Premade Parlays</a>
       <a href="/build-your-own">Build Your Own</a>
       <a href="/personal-stats">Personal Stats</a>
+      <a href="/free-75">Free 75</a>
     </div>
   </div>
   

--- a/docs/premade.html
+++ b/docs/premade.html
@@ -14,6 +14,7 @@
       <a href="/premade">Premade Parlays</a>
       <a href="/build-your-own">Build Your Own</a>
       <a href="/personal-stats">Personal Stats</a>
+      <a href="/free-75">Free 75</a>
     </div>
   </div>
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -522,3 +522,24 @@ body.index-page .dropdown-content {
   font-style: italic;
 }
 
+/* ===================== */
+/* Free 75 Page Styles   */
+/* ===================== */
+body.free75-page {
+  background-color: #85bb65; /* Money green */
+  color: #fff;
+}
+
+.free75-steps {
+  max-width: 600px;
+  margin: 0 auto;
+  text-align: left;
+}
+
+.free75-steps .step {
+  margin: 20px 0;
+  padding: 15px;
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+}
+


### PR DESCRIPTION
## Summary
- add `Free 75` page explaining steps to win a free $75
- style Free 75 page with money green theme
- link new page in navigation and expose via Flask route

## Testing
- `pytest`
- `python -m py_compile App.py`


------
https://chatgpt.com/codex/tasks/task_e_68c06ad619a08332a606fb9a83b15240